### PR TITLE
Fixed alignment bug

### DIFF
--- a/src/meshlab_project.h
+++ b/src/meshlab_project.h
@@ -48,7 +48,7 @@ struct MeshLabProjectMeshInfo {
   std::string filename;
 };
 
-typedef std::vector<MeshLabProjectMeshInfo> MeshLabMeshInfoVector;
+typedef std::vector<MeshLabProjectMeshInfo,Eigen::aligned_allocator<MeshLabProjectMeshInfo>> MeshLabMeshInfoVector;
 
 // Loads MeshLabProjectMeshInfo from a MeshLab project file into the meshes
 // vector. Only reads the first MeshGroup. Returns true if successful.


### PR DESCRIPTION
Fixed an Eigen alignment bug : MeshLabMeshInfoVector should be defined such that it is an aligned vector. 
See https://eigen.tuxfamily.org/dox/group__TopicStlContainers.html for more details.